### PR TITLE
opkg-Definition

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -115,9 +115,9 @@
 
   opkg = {
     extra = {
-      gluon1 = 'http://1.updates.services.ffggrz/packages/gluon-%GS-%GR/%S', -- joergd
-      gluon2 = 'http://2.updates.services.ffggrz/packages/gluon-%GS-%GR/%S', -- marcus
-      gluon3 = 'http://3.updates.services.ffggrz/packages/gluon-%GS-%GR/%S', -- 3
+      modules1 = 'http://1.updates.services.ffggrz/packages/gluon-%GS-%GR/%S',
+      modules2 = 'http://2.updates.services.ffggrz/packages/gluon-%GS-%GR/%S',
+      modules3 = 'http://3.updates.services.ffggrz/packages/gluon-%GS-%GR/%S',
     },
   },
 

--- a/site.conf
+++ b/site.conf
@@ -113,6 +113,14 @@
     },
   },
 
+  opkg = {
+    extra = {
+      gluon1 = 'http://1.updates.services.ffggrz/packages/gluon-%GS-%GR/%S', -- joergd
+      gluon2 = 'http://2.updates.services.ffggrz/packages/gluon-%GS-%GR/%S', -- marcus
+      gluon3 = 'http://3.updates.services.ffggrz/packages/gluon-%GS-%GR/%S', -- 3
+    },
+  },
+
   roles = {
     default = 'node',
     list = {


### PR DESCRIPTION
Die Lösung zieht die packages mit in den autoupdater-Mirror mit ein ... da die Pakete auf jeweils unterschiedlichen Servern zeigt haben wir damit auch weniger Probleme die Packages anzubieten.

Habe das auf meinen WR842 mit den letzten Gluon-master getestet.

Schöne ist dass sich die bei LEDE auch einfach kopieren lassen (modules heißt jetzt offensichtlich packages):
```
cd output
cp -r packages /var/www/2.update.services.ffggrz

```

Lg, Marcus