### PR TITLE
add dns-cache feature

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -14,6 +14,13 @@
                  'fdb5:78b:64cc::13',
   },
 
+  dns = {
+    cacheentries = 5000,
+    servers = {'fdb5:78b:64cc::11',
+               'fdb5:78b:64cc::12',
+               'fdb5:78b:64cc::13',},
+  },
+
   regdom = 'DE',
 
   wifi24 = {


### PR DESCRIPTION
LEDE hat ein neues Feature um für das lokale Client-Netz einen DNS-Cache anzubieten.
Der DNS-Server wird per Router-Advertisement im RDNSS-Feld bekannt gegeben.
Größter Vorteil ist die Auflösung von nextnode ... wie die Clients aber unter normalen Umständen den DNS-Server wählen wird wahrscheinlich eher Zufall sein, da die Gateways auch ihre RA's versenden.

Die 5000-Cache Einträge würden ca. 0,5MB-RAM verbraten ... das sollte sogar ein WR841 problemlos verkraften.

Lg, Marcus