### PR TITLE
add tunneldigger-watchdog

### DIFF
--- a/modules
+++ b/modules
@@ -6,16 +6,20 @@
 ##	GLUON_SITE_FEEDS
 #		for each feed name given, add the corresponding PACKAGES_* lines
 #		documented below
-GLUON_SITE_FEEDS='ffggrz_packages'
+GLUON_SITE_FEEDS='ffggrz_packages ffrl_packages'
 
 ##	PACKAGES_$feedname_REPO
 #		the  git repository from where to clone the package feed
 PACKAGES_FFGGRZ_PACKAGES_REPO=https://github.com/ffggrz/ffggrz-packages.git
+PACKAGES_FFRL_PACKAGES_REPO=https://github.com/ffrl/ffrl-packages
 
 ##	PACKAGES_$feedname_COMMIT
 #		the version/commit of the git repository to clone
 PACKAGES_FFGGRZ_PACKAGES_COMMIT=e54aea7be8357df04f1b4c3111d15cbfdfb9b422
+PACKAGES_FFRL_PACKAGES_COMMIT=434f2181290b129bdfbb09ca16e1d9696c8327be
 
 ##  PACKAGES_$feedname_BRANCH
 #   the branch to check out
 PACKAGES_FFGGRZ_PACKAGES_BRANCH=master
+PACKAGES_FFRL_PACKAGES_BRANCH=master
+

--- a/site.mk
+++ b/site.mk
@@ -24,6 +24,7 @@ GLUON_SITE_PACKAGES := \
 	gluon-neighbour-info \
 	gluon-mesh-batman-adv-15 \
 	gluon-mesh-vpn-tunneldigger \
+	gluon-tunneldigger-watchdog \
 	gluon-radvd \
 	gluon-setup-mode \
 	gluon-status-page \


### PR DESCRIPTION
Der Watchdog prüft alle 5 Minuten ob der Prozess noch lebt indem er die PID mit der im PID-File vergleicht und schaut zusätzlich noch ob über das Interface "mesh-vpn" auch mesh-Verbindungen aktiv sind.
Wie es sich auf Dauer verhält wenn Tunneldigger zwar aktiv ist aber im WAN-Port nichts steckt ist ist mir unklar.

Allerdings gibts derzeit ein Bug: der restart-Prozess scheint wohl in seltenen Fällen zu hängen und produziert immer mehr restart-Prozesse. https://github.com/ffrl/ffrl-packages/issues/10

Soweit ich weiß läuft das Script seit einigen Monaten bei anoymouserver recht zuverlässig.
Ich selbst habe eine vereinfachte Variante mit reboot erfolgreich getestet. https://gist.github.com/Sunz3r/4863edeae6d7ba049cf709522ce0daf6

Änderungen auf meinen WR842 getestet.

Lg, Marcus