### PR TITLE
enable mesh_on_lan per default

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -23,6 +23,8 @@
 
   regdom = 'DE',
 
+  mesh_on_lan = true,
+
   wifi24 = {
     channel = 6,
     supported_rates = {6000, 9000, 12000, 18000, 24000, 36000, 48000, 54000},


### PR DESCRIPTION
Meistens wird mesh_on_lan für die LAN-Ports genutzt und in seltenen Fällen oder Unfällen wird das Client-Netz an den Ports verwendet.
Von daher mein Vorschlag es per default einzuschalten, dieser Wert wird nur für die Erstinstallation genutzt.