### PR TITLE
enabled the password form

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -168,5 +168,9 @@
     owner = {
       obligatory = true
     },
+    remote_login = {
+      show_password_form = true,
+      min_password_length = 6,
+    },
   },
 }


### PR DESCRIPTION
The config mode password field is disabled per default since https://github.com/freifunk-gluon/gluon/pull/1149