### PR TITLE
add firewall exception for querying respondd data

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -6,6 +6,9 @@
 
   prefix4 = '10.181.0.0/18',
   prefix6 = 'fdb5:078b:64cc::/64',
+  extra_prefixes6 = {
+    '2a03:2260:100b::/64',
+  },
 
   timezone = 'CET-1CEST,M3.5.0,M10.5.0/3',
   ntp_servers = {

--- a/site.mk
+++ b/site.mk
@@ -9,6 +9,7 @@ GLUON_FEATURES := \
 	autoupdater \
 	ebtables-filter-multicast \
 	ebtables-filter-ra-dhcp \
+	ebtables-source-filter \
 	mesh-batman-adv-15 \
 	mesh-vpn-fastd \
 	mesh-vpn-tunneldigger \
@@ -28,6 +29,11 @@ GLUON_FEATURES := \
 
 GLUON_SITE_PACKAGES := \
 	iwinfo \
+
+##	GLUON_SITE_PACKAGES_standard
+#		Same as GLUON_SITE_PACKAGES but only for devices of the standard device-class
+
+GLUON_SITE_PACKAGES_standard := \
 	respondd-module-airtime \
 
 ##	DEFAULT_GLUON_RELEASE


### PR DESCRIPTION
- add [`extra_prefixes6`](https://gluon.readthedocs.io/en/latest/package/gluon-ebtables-source-filter.html) to allow respondd queries from servers
- integrate respondd airtime module only for standard devices